### PR TITLE
Voting Fix + Timeout Fix

### DIFF
--- a/public/js/components/ArticleButtons.js
+++ b/public/js/components/ArticleButtons.js
@@ -12,6 +12,10 @@ export default class ArticleButtons extends React.Component {
         this.toggleButton = this.toggleButton.bind(this)
     }
 
+    componentWillUnmount() {
+        clearTimeout(this.timeout)
+    }
+
     callVote(vote) {
         if (!this.canVote()) return 
         ArticleActions.postVote(vote, this.props.id)
@@ -21,7 +25,7 @@ export default class ArticleButtons extends React.Component {
     canVote() {
         if (this.state.clicked) return false
         this.toggleButton()
-        setTimeout(this.toggleButton, 10000)
+        this.timeout = setTimeout(this.toggleButton, 10000)
         return true
     }
 

--- a/public/js/components/ArticleButtons.js
+++ b/public/js/components/ArticleButtons.js
@@ -15,7 +15,7 @@ export default class ArticleButtons extends React.Component {
     callVote(vote) {
         if (!this.canVote()) return 
         ArticleActions.postVote(vote, this.props.id)
-            .then(() => ArticleActions.fetchArticles(ArticleStore.getSort(), ArticleStore.getLastArticle()))
+            .then(() => ArticleActions.fetchArticles(ArticleStore.getSort()))
     }
 
     canVote() {


### PR DESCRIPTION
## Voting Fix
This fixes issue #32, brought up by @Tuanhao earlier tonight.
The issue was the fetchArticles being called after a vote was being passed a `lastArticle`. But you only pass in `lastArticle` for pagination to receive the next set of articles.
