### PR TITLE
Standardize error contents, and remove extra brackets in arrow functions

### DIFF
--- a/routes/article.js
+++ b/routes/article.js
@@ -13,7 +13,7 @@ router.post('/vote', (req, res) => {
     if (amount === 0) {
         res.status(500).send({
             err: "Invalid value for vote",
-            reqBody: req.body
+            givens: req.body
         })
         return
     }
@@ -59,7 +59,7 @@ router.post('/vote', (req, res) => {
         .catch((err) => {
             res.status(500).send({
                 err,
-                reqBody: req.body
+                givens: req.body
             })
         })
 })
@@ -83,7 +83,7 @@ router.get('/top', (req, res) => {
         .catch((err) => {
             res.status(500).send({
                 err: `Articles weren't found: ${err}`,
-                reqQuery: req.query
+                givens: req.query
             })
         })
 })
@@ -102,7 +102,7 @@ router.get('/new', (req, res) => {
         .catch((err) => {
             res.status(500).send({
                 err: `Newest articles weren't found: ${err}`,
-                reqQuery: req.query
+                givens: req.query
             })
         })
 })
@@ -116,7 +116,7 @@ router.get('/:id', (req, res) => {
         .catch((err) => {
             res.status(500).send({
                 err,
-                reqParams: req.params
+                givens: req.params
             })
         })
 })

--- a/routes/keyword.js
+++ b/routes/keyword.js
@@ -8,17 +8,14 @@ const Keyword = require('../models/KeywordModel.js')
 const router = express.Router()
 
 router.get('/:word', (req, res) => {
-    console.log(req.params)
     let word = req.params.word
-    console.log(word)
-    Keyword.find({word: word}).lean().then((wordList) => {
-        console.log(wordList[0])
-        console.log(wordList[0].votes)
-        console.log(word)
+    Keyword.find({ word }).lean().then((wordList) => {
         res.send(wordList[0].votes)
     }).catch((err) => {
-        console.log(err)
-        res.status(500).end()
+        res.status(500).send({
+            err: `Keyword not found: ${err}`,
+            givens: req.params
+        })
     })
 })
 

--- a/test/articles.test.js
+++ b/test/articles.test.js
@@ -51,7 +51,7 @@ describe('/articles Route', () => {
                 .get(`/articles/${fakeId}`)
                 .end((err, res) => {
                     checkValidError(res)
-                    res.body.reqParams.id.should.equal(fakeId)
+                    res.body.givens.id.should.equal(fakeId)
                     done()
                 })
         })
@@ -62,7 +62,7 @@ describe('/articles Route', () => {
                 .get(`/articles/${invalidId}`)
                 .end((err, res) => {
                     checkValidError(res)
-                    res.body.reqParams.id.should.equal(invalidId)
+                    res.body.givens.id.should.equal(invalidId)
                     done()
                 })
         })
@@ -212,7 +212,7 @@ function checkValidError(res) {
     res.should.have.status(500)
     res.body.should.not.be.empty
     res.body.should.have.property('err')
-    res.body.should.have.property('reqParams')
+    res.body.should.have.property('givens')
 }
 
 function checkVotesSorted(res) {


### PR DESCRIPTION
All error responses should now have the following properties:
`err: 'Description of the err as a String or an Object'`
`givens: {'An object that holds the data that was given'}`

~~I also removed the extra brackets in arrow functions when there is only 1 parameter in the article route only. I didn't want to create conflicts for Vikram, as he is modifying the Keywords route.~~
Done for `/keywords/:word`