### PR TITLE
Fetch refactor, sanitize dates and keywords

### DIFF
--- a/public/js/actions/GraphActions.js
+++ b/public/js/actions/GraphActions.js
@@ -26,9 +26,6 @@ export default class GraphActions {
           dataPoints,
         })
       })
-      .catch((err) => {
-        console.log('Error updating graph', err)
-        // TODO: do somthing with error
-      })
+      .catch(err => err)
   }
 }

--- a/scripts/fetchArticles.js
+++ b/scripts/fetchArticles.js
@@ -9,9 +9,9 @@ const REFRESH = 3600000
 const longAgoDate = new Date('1/1/2000').toISOString()
 
 function sanitize(string) {
-  const newString = string.toLowerCase()
-  // Removes all punctuation
-  return newString.replace(/[^0-9a-z ]/g, '')
+  // Removes all punctuation, sets spaces to hyphens, lowers the case
+  const newString = string.toLowerCase().replace(/[^0-9a-z ]/g, '')
+  return newString.replace(/\s+/g, '-')
 }
 
 function getPhrases(article) {

--- a/scripts/fetchArticles.js
+++ b/scripts/fetchArticles.js
@@ -31,14 +31,14 @@ function getPhrases(article) {
 function mapArticleToUpdatedArticle(article) {
   return new Promise((resolve, reject) => {
     Article.findOneAndUpdate({
-      url: article.url
+      url: article.url,
     }, {
-      author: '$author',
-      title: '$title',
-      description: '$description',
-      url: '$url',
-      urlToImage: '$urlToImage',
-      publishedAt: '$publishedAt',
+      author: article.author,
+      title: article.title,
+      description: article.description,
+      url: article.url,
+      urlToImage: article.urlToImage,
+      publishedAt: article.publishedAt,
       keywords: getPhrases(article),
       votes: 0,
     }, {
@@ -56,7 +56,7 @@ function updateNews() {
     .then((res) => {
       const articles = JSON.parse(res).articles
       Promise.all(articles.map(mapArticleToUpdatedArticle))
-        .then(result => console.log(result))
+        .then(() => {})
         .catch(err => err)
     })
     .catch(err => err)

--- a/scripts/fetchArticles.js
+++ b/scripts/fetchArticles.js
@@ -6,6 +6,7 @@ const Article = require('../models/ArticleModel')
 
 // 3 600 000 is 1 hour
 const REFRESH = 3600000
+const longAgoDate = new Date('1/1/2000').toISOString()
 
 function sanitize(string) {
   const newString = string.toLowerCase()
@@ -30,6 +31,7 @@ function getPhrases(article) {
 
 function mapArticleToUpdatedArticle(article) {
   return new Promise((resolve, reject) => {
+    if (article.publishedAt <= longAgoDate) article.publishedAt = new Date()
     Article.findOneAndUpdate({
       url: article.url,
     }, {

--- a/scripts/fetchArticles.js
+++ b/scripts/fetchArticles.js
@@ -31,7 +31,8 @@ function getPhrases(article) {
 
 function mapArticleToUpdatedArticle(article) {
   return new Promise((resolve, reject) => {
-    if (article.publishedAt <= longAgoDate) article.publishedAt = new Date()
+    const publishedAt = (article.publishedAt >= longAgoDate) ?
+      article.publishedAt : (new Date()).toIsoString()
     Article.findOneAndUpdate({
       url: article.url,
     }, {
@@ -40,7 +41,7 @@ function mapArticleToUpdatedArticle(article) {
       description: article.description,
       url: article.url,
       urlToImage: article.urlToImage,
-      publishedAt: article.publishedAt,
+      publishedAt,
       keywords: getPhrases(article),
       votes: 0,
     }, {


### PR DESCRIPTION
## Fetch refactor
I made article fetching faster and optimized by using `upsert`, instead of making a request to the database, modifying data, making a new request, then responding to the client.

## Sanitization
Keywords that have spaces in them will have the spaces replaced to hyphens 
`50 ShAdEs Of GrAy` -> `50-shades-of-gray`

Dates that are before January 1st 2000 are now set to the current date (to match the tests)

## Minor change
I also changed how Vikram handled an error in GraphActions because eslint was giving a warning for it